### PR TITLE
Colors (and other chalk styles)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,20 @@
 # yargonaut
 
+> Decorate yargs content with chalk styles and figlet fonts
+
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/feross/standard)
 [![npm version](https://img.shields.io/npm/v/yargonaut.svg)](https://npmjs.org/package/yargonaut)
 
-```
-▄██   ▄      ▄████████    ▄████████    ▄██████▄   ▄██████▄  ███▄▄▄▄      ▄████████ ███    █▄      ███
-███   ██▄   ███    ███   ███    ███   ███    ███ ███    ███ ███▀▀▀██▄   ███    ███ ███    ███ ▀█████████▄
-███▄▄▄███   ███    ███   ███    ███   ███    █▀  ███    ███ ███   ███   ███    ███ ███    ███    ▀███▀▀██
-▀▀▀▀▀▀███   ███    ███  ▄███▄▄▄▄██▀  ▄███        ███    ███ ███   ███   ███    ███ ███    ███     ███   ▀
-▄██   ███ ▀███████████ ▀▀███▀▀▀▀▀   ▀▀███ ████▄  ███    ███ ███   ███ ▀███████████ ███    ███     ███
-███   ███   ███    ███ ▀███████████   ███    ███ ███    ███ ███   ███   ███    ███ ███    ███     ███
-███   ███   ███    ███   ███    ███   ███    ███ ███    ███ ███   ███   ███    ███ ███    ███     ███
- ▀█████▀    ███    █▀    ███    ███   ████████▀   ▀██████▀   ▀█   █▀    ███    █▀  ████████▀     ▄████▀
-                         ███    ███
+yargonaut is *the* content decorator for [yargs](https://www.npmjs.com/package/yargs),
+allowing you to customize your yargs-based CLI output using
+[chalk](https://www.npmjs.com/package/chalk) [styles](https://www.npmjs.com/package/chalk#styles)
+and/or [figlet](https://www.npmjs.com/package/figlet) fonts ... easily!
 
-```
+*Why?* Because CLI apps with color and ASCII Art are more fun!
 
-Customize your yargs-based CLI content with ASCII Art fonts ... easily!
+*Could you customize yargs text, possibly using chalk or figlet, **without** yargonaut?* Absolutely. But yargonaut makes it so easy! And yargonaut supports all locales that yargs and figlet support - out of the box.
 
-yargonaut brings the creative awesomeness of [figlet](https://www.npmjs.com/package/figlet)
-to the world of CLI goodness that is [yargs](https://www.npmjs.com/package/yargs).
-
-Why? Because ASCII Art is fun!
-
-Could you customize yargs text, possibly using figlet, **without** yargonaut?
-Absolutely. But yargonaut makes it so easy! And yargonaut supports all locales
-that yargs and figlet support - out of the box.
-
-Could ASCII Art fonts be annoying in CLI apps? Well, sure. But used tastefully,
-it can add a degree of creative flair to make your CLI stand out. Use wisely!
+*Could terminal coloring or ASCII Art fonts be annoying in CLI apps?* Well, sure. But used tastefully, it can add a degree of creative flair to make your CLI stand out. Use wisely!
 
 # Install
 
@@ -36,22 +22,22 @@ it can add a degree of creative flair to make your CLI stand out. Use wisely!
 npm install --save yargonaut yargs
 ```
 
+```js
+var yargonaut = require('yargonaut') // yargonaut first!
+var yargs = require('yargs') // then yargs
+```
+
 yargonaut assumes you have yargs installed independently.
 
-To automatically support all locales that yargs supports, make sure to
-`require('yargonaut')` in code *before* you `require('yargs')`. This should be
-natural, since you'll need to configure yargonaut before yargs parses CLI args
-anyway.
+To automatically support all locales that yargs supports, make sure to `require('yargonaut')` in code *before* you `require('yargs')`. **This is important!** If you choose to ignore this, yargonaut will attempt workarounds as best it can, but any issues caused by incorrect ordering of `require()` statements will **not** be given priority. The ordering should be natural, since you'll need to configure yargonaut before yargs parses CLI args anyway.
 
-Note that yargonaut **does not** wrap yargs and **is not** a replacement for yargs.
-It's built to work with yargs side-by-side, and it doesn't lock you in to a
-particular version of yargs, though internal string customization is only supported
-in yargs v3.16.1 and up.
+Note that yargonaut **does not** wrap yargs and **is not** a replacement for yargs. It's built to work with yargs side-by-side, and it doesn't lock you in to a particular version of yargs, though internal string customization is only supported in yargs v3.16.1 and up.
 
-If anything goes wrong, yargonaut attempts to fail gracefully and silently, so
-your CLI still works, just without the cool fonts.
+If anything goes wrong, yargonaut attempts to fail gracefully and silently, so your CLI still works, just without the cool colors/fonts.
 
 # Examples
+
+Screenshots and/or animated GIFs coming soon! Color examples don't work too well without them. :)
 
 ## Use a single figlet font for all top-level yargs strings:
 
@@ -260,6 +246,13 @@ Render error messages using the specified figlet font.
 - Returns: `yargonaut` singleton
 - `font`: string, name of figlet font
 
+### errorsStyle(style)
+
+Apply the given [chalk style](https://www.npmjs.com/package/chalk#styles) to error messages, e.g. `errorsStyle('red.bold')`.
+
+- Returns: `yargonaut` singleton
+- `style`: string, the dot-delimited chalk style (color/modifier) to use
+
 ### font(font, [key])
 
 Render yargs strings using the specified figlet font. Optionally specify which
@@ -276,6 +269,13 @@ Render help content strings using the specified figlet font.
 - Returns: `yargonaut` singleton
 - `font`: string, name of figlet font
 
+### helpStyle(style)
+
+Apply the given [chalk style](https://www.npmjs.com/package/chalk#styles) to help content, e.g. `helpStyle('green.underline')`.
+
+- Returns: `yargonaut` singleton
+- `style`: string, the dot-delimited chalk style (color/modifier) to use
+
 ### ocd(fn)
 
 For obsessive control over string transformations, provide a function that
@@ -288,6 +288,14 @@ yargonaut will call for every yargs string (every y18n lookup).
   - `newString`: string, the new string as rendered by yargonaut/figlet
   - `figlet`: figlet, the figlet instance
   - `font`: string, the configured figlet font for the key
+
+### style(style, [key])
+
+Apply the given [chalk style](https://www.npmjs.com/package/chalk#styles) to all yargs strings, e.g. `style('blue')`. Optionally specify which yargs string(s) the style should apply to.
+
+- Returns: `yargonaut` singleton
+- `style`: string, the dot-delimited chalk style (color/modifier) to use
+- `key`: string or array of strings, optional key(s) the style should apply to
 
 ### transformUpToFirstColon(key)
 
@@ -324,7 +332,7 @@ Get a list of known help content strings subject to y18n lookup and yargonaut re
 
 - Returns: array of strings, representing configured help content yargs strings
 
-## Convenience methods for playing with fonts
+## Convenience methods for playing with stuff
 
 ### asFont(text, font, [throwErr])
 
@@ -334,6 +342,12 @@ Render any text as the given figlet font and return as string.
 - `text`: string, the text to render
 - `font`: string, the figlet font to use for rendering
 - `throwErr`: boolean, optional flag to throw any error that might occur, defaults to `false`
+
+### chalk()
+
+Get access to the `chalk` instance used by yargonaut. In case you want to color your own strings without having to `require('chalk')` yourself.
+
+- Returns: `chalk`, the chalk instance
 
 ### figlet()
 

--- a/index.js
+++ b/index.js
@@ -140,6 +140,10 @@ function Yargonaut () {
     return figlet
   }
 
+  self.chalk = function () {
+    return chalk
+  }
+
   // private transforms
   function wholeString (str) {
     return { render: str, nonRender: '' }

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ function Yargonaut () {
     keys.forEach(function (k) {
       styles[k] = style
     })
-    if (yargs && yargs.updateLocale) applyStyleWorkaround()
+    if (yargs && yargs.updateLocale) applyStyleWorkaround(keys)
   }
 
   function applyFont (font, keys, force) {
@@ -170,11 +170,11 @@ function Yargonaut () {
       if (!yargsKeys[k]) yargsKeys[k] = { transform: wholeString, error: null }
       else if (force && yargsKeys[k].transform === null) yargsKeys[k].transform = wholeString
     })
-    if (yargs && yargs.updateLocale) applyFontWorkaround()
+    if (yargs && yargs.updateLocale) applyFontWorkaround(keys)
   }
 
-  function applyStyleWorkaround () {
-    Object.keys(styles).forEach(function (k) {
+  function applyStyleWorkaround (keys) {
+    keys.forEach(function (k) {
       if (workaround[k]) {
         if (typeof workaround[k] === 'string') workaround[k] = doStyle(k, chalk.stripColor(workaround[k]), styles[k])
         else {
@@ -197,8 +197,8 @@ function Yargonaut () {
     yargs.updateLocale(workaround)
   }
 
-  function applyFontWorkaround () {
-    Object.keys(fonts).forEach(function (k) {
+  function applyFontWorkaround (keys) {
+    keys.forEach(function (k) {
       if (workaround[k]) {
         if (typeof workaround[k] === 'string') workaround[k] = doRender(k, workaround[k], fonts[k])
         else {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ var chalk = require('chalk')
 module.exports = new Yargonaut()
 
 function Yargonaut () {
-
   var self = this
   var yargs = hack()
   var fonts = {}
@@ -328,5 +327,4 @@ function Yargonaut () {
       return null
     }
   }
-
 }

--- a/index.js
+++ b/index.js
@@ -4,18 +4,22 @@ var path = require('path')
 
 var parentRequire = require('parent-require')
 var figlet = require('figlet')
+var chalk = require('chalk')
 
 module.exports = new Yargonaut()
 
 function Yargonaut () {
 
   var self = this
-  var yargs = hack(self)
+  var yargs = hack()
   var fonts = {}
+  var styles = {}
+  var workaround = {}
   var ocdf = null
   var defaultFont = 'Standard'
 
   var yargsKeys = {
+    // supporting fonts and styles
     'Commands:': { transform: wholeString, error: false },
     'Options:': { transform: wholeString, error: false },
     'Examples:': { transform: wholeString, error: false },
@@ -28,7 +32,17 @@ function Yargonaut () {
     'Argument check failed: %s': { transform: upToFirstColon, error: true },
     'Implications failed:': { transform: wholeString, error: true },
     'Not enough arguments following: %s': { transform: upToFirstColon, error: true },
-    'Invalid JSON config file: %s': { transform: upToFirstColon, error: true }
+    'Invalid JSON config file: %s': { transform: upToFirstColon, error: true },
+    // supporting styles only (by default)
+    'boolean': { transform: null, error: null },
+    'count': { transform: null, error: null },
+    'string': { transform: null, error: null },
+    'array': { transform: null, error: null },
+    'required': { transform: null, error: null },
+    'default:': { transform: null, error: null },
+    'choices:': { transform: null, error: null },
+    'generated-value': { transform: null, error: null },
+    'Argument: %s, Given: %s, Choices: %s': { transform: null, error: true }
   }
 
   // chainable config API methods
@@ -44,7 +58,23 @@ function Yargonaut () {
 
   self.font = function (font, key) {
     var keys = key ? [].concat(key) : self.getAllKeys()
-    applyFont(font, keys)
+    applyFont(font, keys, key !== undefined)
+    return self
+  }
+
+  self.helpStyle = function (style) {
+    applyStyle(style, self.getHelpKeys())
+    return self
+  }
+
+  self.errorsStyle = function (style) {
+    applyStyle(style, self.getErrorKeys())
+    return self
+  }
+
+  self.style = function (style, key) {
+    var keys = key ? [].concat(key) : self.getAllKeys()
+    applyStyle(style, keys)
     return self
   }
 
@@ -122,30 +152,70 @@ function Yargonaut () {
   }
 
   // private config methods
-  function applyFont (font, keys) {
+  function applyStyle (style, keys) {
+    if (typeof style !== 'string') return
+    keys.forEach(function (k) {
+      styles[k] = style
+    })
+    if (yargs && yargs.updateLocale) applyStyleWorkaround()
+  }
+
+  function applyFont (font, keys, force) {
     if (typeof font !== 'string') font = defaultFont
     keys.forEach(function (k) {
       fonts[k] = font
       if (!yargsKeys[k]) yargsKeys[k] = { transform: wholeString, error: null }
+      else if (force && yargsKeys[k].transform === null) yargsKeys[k].transform = wholeString
     })
-    if (yargs && yargs.updateLocale) applyFontWorkaround(font, keys)
+    if (yargs && yargs.updateLocale) applyFontWorkaround()
   }
 
-  function applyFontWorkaround (font, keys) {
-    var u = {}
-    var rendered
-    Object.keys(fonts).forEach(function (k) {
-      rendered = doRender(k, k, fonts[k])
-      if (yargsKeys[k].plural) {
-        u[k] = {
-          one: rendered,
-          other: doRender(yargsKeys[k].plural, yargsKeys[k].plural, fonts[k])
+  function applyStyleWorkaround () {
+    Object.keys(styles).forEach(function (k) {
+      if (workaround[k]) {
+        if (typeof workaround[k] === 'string') workaround[k] = doStyle(k, chalk.stripColor(workaround[k]), styles[k])
+        else {
+          workaround[k] = {
+            one: doStyle(k, chalk.stripColor(workaround[k].one), styles[k]),
+            other: doStyle(yargsKeys[k].plural, chalk.stripColor(workaround[k].other), styles[k])
+          }
         }
       } else {
-        u[k] = rendered
+        if (yargsKeys[k] && yargsKeys[k].plural) {
+          workaround[k] = {
+            one: doStyle(k, k, styles[k]),
+            other: doStyle(yargsKeys[k].plural, yargsKeys[k].plural, styles[k])
+          }
+        } else {
+          workaround[k] = doStyle(k, k, styles[k])
+        }
       }
     })
-    yargs.updateLocale(u)
+    yargs.updateLocale(workaround)
+  }
+
+  function applyFontWorkaround () {
+    Object.keys(fonts).forEach(function (k) {
+      if (workaround[k]) {
+        if (typeof workaround[k] === 'string') workaround[k] = doRender(k, workaround[k], fonts[k])
+        else {
+          workaround[k] = {
+            one: doRender(k, workaround[k].one, fonts[k]),
+            other: doRender(yargsKeys[k].plural, workaround[k].other, fonts[k])
+          }
+        }
+      } else {
+        if (yargsKeys[k] && yargsKeys[k].plural) {
+          workaround[k] = {
+            one: doRender(k, k, fonts[k]),
+            other: doRender(yargsKeys[k].plural, yargsKeys[k].plural, fonts[k])
+          }
+        } else {
+          workaround[k] = doRender(k, k, fonts[k])
+        }
+      }
+    })
+    yargs.updateLocale(workaround)
   }
 
   function applyTransform (transform, keys) {
@@ -156,8 +226,17 @@ function Yargonaut () {
   }
 
   // private logic to intercept y18n methods
+  function doStyle (key, orig, style) {
+    var chain = chalk
+    style.split('.').forEach(function (s) {
+      if (chain[s]) chain = chain[s]
+    })
+    return typeof chain === 'function' ? chain(orig) : orig
+  }
+
   function doRender (key, orig, font) {
     var fn = yargsKeys[key] ? yargsKeys[key].transform : upToFirstColon
+    if (fn === null) return orig
     var split = fn(orig)
     return self.asFont(split.render, font) + split.nonRender
   }
@@ -215,6 +294,7 @@ function Yargonaut () {
       }
 
       function tweak (key, origString, newString, figlet, font) {
+        if (styles[key]) newString = doStyle(key, newString, styles[key])
         return ocdf ? ocdf(key, origString, newString, figlet, font) : newString
       }
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "standard": "^5.0.0"
   },
   "dependencies": {
+    "chalk": "^1.1.1",
     "figlet": "^1.1.1",
     "parent-require": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/nexdrew/yargonaut#readme",
   "devDependencies": {
-    "standard": "^5.0.0"
+    "standard": "^5.2.1"
   },
   "dependencies": {
     "chalk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yargonaut",
   "version": "1.0.0",
-  "description": "Customize yargs text with figlet fonts",
+  "description": "Decorate yargs content with chalk styles and figlet fonts",
   "main": "index.js",
   "scripts": {
     "test": "standard"
@@ -24,7 +24,11 @@
     "ascii",
     "ansi",
     "locale",
-    "fun"
+    "fun",
+    "chalk",
+    "color",
+    "terminal",
+    "cli"
   ],
   "author": {
     "name": "Andrew Goode",


### PR DESCRIPTION
Based on the great suggestion by @fulmicoton to [add color support to `yargs` content](https://github.com/bcoe/yargs/issues/251), add color/style support to `yargonaut` instead.

Now you can use `yargonaut` to jazz up your CLI with `figlet` fonts _and/or_ `chalk` styles! Awesome!

_NB_: Documentation updates still pending. Will try to tackle that soon!
